### PR TITLE
Add support to lint sass tree 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 4
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ function linter(content, options, context, callback) {
 }
 
 function lintFile(processFile, filePath, content, options, context, callback) {
-    console.log(options)
     var lintOptions = assign({}, options, {
         code: fs.readFileSync(context.resourcePath, { encoding: 'utf-8' }),
         syntax: path.extname(filePath).replace('.', ''),
@@ -57,7 +56,6 @@ function lintFile(processFile, filePath, content, options, context, callback) {
     if (processFile) {
         stylelint.lint(lintOptions)
             .then(data => {
-                console.log(data.results)
                 return data.results[0];
             })
             .then(result => processResult(result, content, options, context, callback, filePath))

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ function linter(content, options, context, callback) {
     }
 
     var lintOptions = assign({}, options, {
-        code: fs.readFileSync(context.resourcePath, { encoding: 'utf-8' }),
         syntax: path.extname(filePath).replace('.', ''),
         formatter: 'json'
     });

--- a/index.js
+++ b/index.js
@@ -46,31 +46,35 @@ function linter(content, options, context, callback) {
 
     if (processFile) {
         stylelint.lint(lintOptions)
-            .then(result => { return result.results[0]; })
-            .then(result => {
-                if (options.displayOutput && result.warnings.length > 0) {
-                    console.log(chalk.blue.underline.bold(filePath));
-                }
-                result.warnings.forEach(warning => {
-                    var position = `${warning.line}:${warning.column}`;
-                    if (warning.severity === 'warning') {
-                        if (options.displayOutput) {
-                            console.log(chalk.yellow(`${position} ${warning.text}`));
+            .then(data => {
+                data.results.forEach(result => {
+                    if (options.displayOutput && result.warnings.length > 0) {
+                        console.log(chalk.blue.underline.bold(result.source));
+                    }
+                    result.warnings.forEach(warning => {
+                        var position = `${warning.line}:${warning.column}`;
+                        if (warning.severity === 'warning') {
+                            if (options.displayOutput) {
+                                console.log(chalk.yellow(`${position} ${warning.text}`));
+                            }
+                            if (options.webpackWarnings) {
+                                context.emitWarning(`${position} ${warning.text}`);
+                            }
+                        } else if (warning.severity === 'error') {
+                            if (options.displayOutput) {
+                                console.log(chalk.red(`${position} ${warning.text}`));
+                            }
+                            if (options.webpackErrors) {
+                                context.emitError(`${position} ${warning.text}`);
+                            }
                         }
-                        context.emitWarning(`${position} ${warning.text}`);
-                    } else if (warning.severity === 'error') {
-                        if (options.displayOutput) {
-                            console.log(chalk.red(`${position} ${warning.text}`));
-                        }
-                        context.emitError(`${position} ${warning.text}`);
+                    });
+                    console.log(chalk.blue('\n Come on, fix you sass nigga (Last check: ' + new Date() + ')'));
+                    if (options.displayOutput && result.warnings.length > 0) {
+                        console.log('');
                     }
                 });
-                if (options.displayOutput && result.warnings.length > 0) {
-                    console.log('');
-                }
                 callback(null, content);
-            }).catch(error => {
-                callback(error);
             });
     } else if (callback) {
         callback(null, content);
@@ -82,7 +86,7 @@ function linter(content, options, context, callback) {
  *
  * @param {string|buffer} content = the content to be linted
  */
-module.exports = function(content) {
+module.exports = function (content) {
     this.cacheable && this.cacheable();
     var callback = this.async();
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ var assign = require('object-assign'),
 var defaultOptions = {
     configFile: './.stylelint.config.js',
     displayOutput: true,
-    ignoreCache: false
+    ignoreCache: false,
+    webpackWarnings: true,
+    webpackErrors: true,
+    files: null
 };
 
 var lintedFiles = [];
@@ -32,12 +35,42 @@ function linter(content, options, context, callback) {
         }
     }
 
-    // Display Path is what we show to the user
     var filePath = context.resourcePath;
     if (filePath.indexOf(__dirname) === 0) {
         filePath = filePath.replace(__dirname, '.');
     }
 
+    if (options.files) {
+        lintFiles(processFile, filePath, content, options, context, callback);
+    } else {
+        lintFile(processFile, filePath, content, options, context, callback);
+    }
+}
+
+function lintFile(processFile, filePath, content, options, context, callback) {
+    console.log(options)
+    var lintOptions = assign({}, options, {
+        code: fs.readFileSync(context.resourcePath, { encoding: 'utf-8' }),
+        syntax: path.extname(filePath).replace('.', ''),
+        formatter: 'json'
+    });
+    if (processFile) {
+        stylelint.lint(lintOptions)
+            .then(data => {
+                console.log(data.results)
+                return data.results[0];
+            })
+            .then(result => processResult(result, content, options, context, callback, filePath))
+            .catch(error => {
+                callback(error);
+            });
+        callback(null, content);
+    } else if (callback) {
+        callback(null, content);
+    }
+}
+
+function lintFiles(processFile, filePath, content, options, context, callback) {
     var lintOptions = assign({}, options, {
         syntax: path.extname(filePath).replace('.', ''),
         formatter: 'json'
@@ -47,36 +80,51 @@ function linter(content, options, context, callback) {
         stylelint.lint(lintOptions)
             .then(data => {
                 data.results.forEach(result => {
-                    if (options.displayOutput && result.warnings.length > 0) {
-                        console.log(chalk.blue.underline.bold(result.source));
-                    }
-                    result.warnings.forEach(warning => {
-                        var position = `${warning.line}:${warning.column}`;
-                        if (warning.severity === 'warning') {
-                            if (options.displayOutput) {
-                                console.log(chalk.yellow(`${position} ${warning.text}`));
-                            }
-                            if (options.webpackWarnings) {
-                                context.emitWarning(`${position} ${warning.text}`);
-                            }
-                        } else if (warning.severity === 'error') {
-                            if (options.displayOutput) {
-                                console.log(chalk.red(`${position} ${warning.text}`));
-                            }
-                            if (options.webpackErrors) {
-                                context.emitError(`${position} ${warning.text}`);
-                            }
-                        }
-                    });
-                    if (options.displayOutput && result.warnings.length > 0) {
-                        console.log('');
-                    }
+                    processResult(result, content, options, context, callback);
                 });
-                console.log(chalk.blue('\n Come on, fix you sass nigga (Last check: ' + new Date() + ')'));
                 callback(null, content);
+            })
+            .catch(error => {
+                callback(error);
             });
     } else if (callback) {
         callback(null, content);
+    }
+}
+
+function processResult(result, content, options, context, callback, filePath) {
+    if (options.displayOutput && result.warnings.length > 0) {
+        var path = filePath ? filePath : result.source;
+        console.log(chalk.blue.underline.bold(path));
+    }
+    result.warnings.forEach(warning => {
+        var position = `${warning.line}:${warning.column}`;
+        if (!warning.severity) {
+            if (options.displayOutput) {
+                console.log(chalk.cyan(`${warning.text}`));
+            }
+            if (options.webpackErrors) {
+                context.emitError(`${warning.text}`);
+            }
+        }
+        else if (warning.severity === 'warning') {
+            if (options.displayOutput) {
+                console.log(chalk.yellow(`${position} ${warning.text}`));
+            }
+            if (options.webpackWarnings) {
+                context.emitWarning(`${position} ${warning.text}`);
+            }
+        } else if (warning.severity === 'error') {
+            if (options.displayOutput) {
+                console.log(chalk.red(`${position} ${warning.text}`));
+            }
+            if (options.webpackErrors) {
+                context.emitError(`${position} ${warning.text}`);
+            }
+        }
+    });
+    if (options.displayOutput && result.warnings.length > 0) {
+        console.log('');
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -68,11 +68,11 @@ function linter(content, options, context, callback) {
                             }
                         }
                     });
-                    console.log(chalk.blue('\n Come on, fix you sass nigga (Last check: ' + new Date() + ')'));
                     if (options.displayOutput && result.warnings.length > 0) {
                         console.log('');
                     }
                 });
+                console.log(chalk.blue('\n Come on, fix you sass nigga (Last check: ' + new Date() + ')'));
                 callback(null, content);
             });
     } else if (callback) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/adrianhall/stylelint-loader",
   "peerDependencies": {
-    "stylelint": "^4.1.0"
+    "stylelint": "^4.2.0"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,23 +27,24 @@
   },
   "homepage": "https://github.com/adrianhall/stylelint-loader",
   "peerDependencies": {
-    "stylelint": "^3.2.0"
+    "stylelint": "^4.1.0"
   },
   "dependencies": {
+    "chalk": "^1.1.1",
     "loader-utils": "^0.2.12",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
+    "chai": "^3.5.0",
     "css-loader": "^0.23.1",
-    "extract-text-webpack-plugin": "^1.0.0",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "memory-fs": "^0.3.0",
-    "mocha": "^2.3.4",
+    "mocha": "^2.4.4",
     "node-sass": "^3.4.2",
     "sass-loader": "^3.1.2",
     "style-loader": "^0.13.0",
-    "webpack": "^1.12.9",
+    "webpack": "^1.12.12",
     "webpack-sources": "^0.1.0"
   }
 }


### PR DESCRIPTION
- added .editorconfig  
- added support to lint sass tree (use [standard](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/node-api.md#files) query param for styles in stylelint)
- Special params `webpackWarnings` and `webpackErrors` allow disabling the duplicate info (if `displayOutput: true`) in webpack
- added support to handle non valid config stylelint file:

```
if (!warning.severity) { /* case when stylelint config is not valid */}
```
- refactor `lint` function
- update dependencies

**Todo:**
-  fix unit tests
- update readme
