### PR TITLE
Remove useless lint option

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,6 @@ function linter(content, options, context, callback) {
 
     lintOptions = assign({}, options, {
         files: context.resourcePath,
-        syntax: path.extname(filePath).replace('.', ''),
         formatter: 'json'
     });
 


### PR DESCRIPTION
The syntax option is now useless as the syntax is automatically inferred since stylelint@7.0.0

Fixes : https://github.com/adrianhall/stylelint-loader/issues/15
More info : https://github.com/stylelint/stylelint/issues/1676
